### PR TITLE
Regex substitutions in SIZE files are case insensitive

### DIFF
--- a/NekTests.py
+++ b/NekTests.py
@@ -2800,10 +2800,10 @@ class Vortex2(NekTestCase):
 
         lines = [re.sub(
             r'( {6}parameter *)\(lx1=10,ly1=lx1,lz1=1,lelt=80,lelv=lelt\)( *)',
-            r'\g<1>(lx1=8,ly1=lx1,lz1=1,lelt=80,lelv=lelt)\g<2>', l) for l in lines]
+            r'\g<1>(lx1=8,ly1=lx1,lz1=1,lelt=80,lelv=lelt)\g<2>', l, flags=re.I) for l in lines]
         lines = [re.sub(
             r'( {6}parameter *)\(lxd=15,lyd=lxd,lzd=1\)( *)',
-            r'\g<1>(lxd=12,lyd=lxd,lzd=1)\g<2>', l) for l in lines]
+            r'\g<1>(lxd=12,lyd=lxd,lzd=1)\g<2>', l, flags=re.I) for l in lines]
 
         with open(size_file_path, 'w') as f:
             f.writelines(lines)

--- a/lib/nekFileConfig.py
+++ b/lib/nekFileConfig.py
@@ -60,7 +60,7 @@ def config_basics_inc(infile, outfile, nelm):
     with open(infile, 'r') as f:
         lines = f.readlines()
 
-    lines = [re.sub(r'(.*nelm *= *)[ 0-9]+(.*)', r'\g<1>{0}\g<2>'.format(nelm), l)
+    lines = [re.sub(r'(.*nelm *= *)[ 0-9]+(.*)', r'\g<1>{0}\g<2>'.format(nelm), l, flags=re.I)
              for l in lines]
 
     with open(outfile, 'w') as f:
@@ -74,15 +74,15 @@ def config_size(infile, outfile, lx2=None, ly2=None, lz2=None):
 
     if lx2:
         lines = [re.sub(r'(^ {6}parameter *\( *lx2 *= *)\S+?( *\))',
-                        r'\g<1>{0}\g<2>'.format(lx2), l)
+                        r'\g<1>{0}\g<2>'.format(lx2), l, flags=re.I)
                  for l in lines]
     if ly2:
         lines = [re.sub(r'(^ {6}parameter *\( *ly2 *= *)\S+?( *\))',
-                        r'\g<1>{0}\g<2>'.format(ly2), l)
+                        r'\g<1>{0}\g<2>'.format(ly2), l, flags=re.I)
                  for l in lines]
     if lz2:
         lines = [re.sub(r'(^ {6}parameter *\( *lz2 *= *)\S+?( *\))',
-                        r'\g<1>{0}\g<2>'.format(lz2), l)
+                        r'\g<1>{0}\g<2>'.format(lz2), l, flags=re.I)
                  for l in lines]
 
     with open(outfile, 'w') as f:


### PR DESCRIPTION
This addresses issue #9.

In NekTests.py, the SIZE files are modified through regex substitutions.  Prior to this PR, the regex searches were case sensitive (the default).  However, the SIZE files are case insensitive (allowed by FORTRAN).  This meant that, if a SIZE file had inconsistent capitalization, the regex search would not find them, and the intended substitution would not occur.  This problem manifested itself in mhd/SIZE.

In this PR, I've made the regex substitutions case insensitive whenever a SIZE file is modified.   