### PR TITLE
Labeled expected failures using decorator

### DIFF
--- a/NekTests.py
+++ b/NekTests.py
@@ -1021,7 +1021,6 @@ class ExtCyl(NekTestCase):
 # #  fs_2; st1.rea, st2.rea, std_wv.rea
 # ####################################################################
 
-# TODO: fs_2/st1.rea tests fail.  They also fail legacy tests in the same ways
 class Fs2_St1(NekTestCase):
     example_subdir  = 'fs_2'
     case_name        = 'st1'
@@ -1030,6 +1029,7 @@ class Fs2_St1(NekTestCase):
         self.build_tools(['genmap'])
         self.run_genmap()
 
+    @unittest.expectedFailure
     @pn_pn_serial
     def test_PnPn_Serial(self):
         self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
@@ -1040,6 +1040,7 @@ class Fs2_St1(NekTestCase):
         self.assertIsNotNullDelayed(phrase, 'ABORT: ')
         self.assertDelayedFailures()
 
+    @unittest.expectedFailure
     @pn_pn_parallel
     def test_PnPn_Parallel(self):
         self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
@@ -1050,6 +1051,7 @@ class Fs2_St1(NekTestCase):
         self.assertIsNotNullDelayed(phrase, 'ABORT: ')
         self.assertDelayedFailures()
 
+    @unittest.expectedFailure
     @pn_pn_2_serial
     def test_PnPn2_Serial(self):
         self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
@@ -1067,6 +1069,7 @@ class Fs2_St1(NekTestCase):
 
         self.assertDelayedFailures()
 
+    @unittest.expectedFailure
     @pn_pn_2_parallel
     def test_PnPn2_Parallel(self):
         self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
@@ -1085,7 +1088,6 @@ class Fs2_St1(NekTestCase):
         self.move_logs()
 
 
-# TODO: fs_2/st2.rea tests fail.  They also fail legacy tests in the same ways
 class Fs2_St2(NekTestCase):
     example_subdir  = 'fs_2'
     case_name        = 'st2'
@@ -1094,6 +1096,7 @@ class Fs2_St2(NekTestCase):
         self.build_tools(['genmap'])
         self.run_genmap()
 
+    @unittest.expectedFailure
     @pn_pn_serial
     def test_PnPn_Serial(self):
         self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
@@ -1104,6 +1107,7 @@ class Fs2_St2(NekTestCase):
         self.assertIsNotNullDelayed(phrase, 'ABORT: ')
         self.assertDelayedFailures()
 
+    @unittest.expectedFailure
     @pn_pn_parallel
     def test_PnPn_Parallel(self):
         self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
@@ -1114,6 +1118,7 @@ class Fs2_St2(NekTestCase):
         self.assertIsNotNullDelayed(phrase, 'ABORT: ')
         self.assertDelayedFailures()
 
+    @unittest.expectedFailure
     @pn_pn_2_serial
     def test_PnPn2_Serial(self):
         self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
@@ -1131,6 +1136,7 @@ class Fs2_St2(NekTestCase):
 
         self.assertDelayedFailures()
 
+    @unittest.expectedFailure
     @pn_pn_2_parallel
     def test_PnPn2_Parallel(self):
         self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
@@ -1156,6 +1162,7 @@ class Fs2_StdWv(NekTestCase):
         self.build_tools(['genmap'])
         self.run_genmap()
 
+    @unittest.expectedFailure
     @pn_pn_serial
     def test_PnPn_Serial(self):
         self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
@@ -1166,6 +1173,7 @@ class Fs2_StdWv(NekTestCase):
         self.assertIsNotNullDelayed(phrase, 'ABORT: ')
         self.assertDelayedFailures()
 
+    @unittest.expectedFailure
     @pn_pn_parallel
     def test_PnPn_Parallel(self):
         self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
@@ -1176,6 +1184,7 @@ class Fs2_StdWv(NekTestCase):
         self.assertIsNotNullDelayed(phrase, 'ABORT: ')
         self.assertDelayedFailures()
 
+    @unittest.expectedFailure
     @pn_pn_2_serial
     def test_PnPn2_Serial(self):
         self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
@@ -1193,6 +1202,7 @@ class Fs2_StdWv(NekTestCase):
 
         self.assertDelayedFailures()
 
+    @unittest.expectedFailure
     @pn_pn_2_parallel
     def test_PnPn2_Parallel(self):
         self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
@@ -1222,9 +1232,9 @@ class FsHydro(NekTestCase):
         self.build_tools(['genmap'])
         self.run_genmap()
 
+    @unittest.expectedFailure
     @pn_pn_serial
     def test_PnPn_Serial(self):
-        # TODO: test fails in here and in legacy tests
         self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
         self.build_nek()
         self.run_nek(step_limit=1000)
@@ -1233,9 +1243,9 @@ class FsHydro(NekTestCase):
         self.assertIsNotNullDelayed(phrase, 'ABORT')
         self.assertDelayedFailures()
 
+    @unittest.expectedFailure
     @pn_pn_parallel
     def test_PnPn_Parallel(self):
-        # TODO: test fails in here and in legacy tests
         self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
         self.build_nek()
         self.run_nek(step_limit=1000)
@@ -1293,6 +1303,7 @@ class Hemi(NekTestCase):
         self.build_tools(['genmap'])
         self.run_genmap()
 
+    @unittest.expectedFailure
     @pn_pn_serial
     def test_PnPn_Serial(self):
         self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
@@ -1305,12 +1316,12 @@ class Hemi(NekTestCase):
         gmres = self.get_value_from_log('gmres: ', column=-7,)
         self.assertAlmostEqualDelayed(gmres, target_val=0., delta=39., label='gmres')
 
-        # TODO: This fails here and in legacy tests
         wmax = self.get_value_from_log('wmax', column=-2, row=-1)
         self.assertAlmostEqualDelayed(wmax, target_val=4.9173E-01, delta=1e-06, label='wmax')
 
         self.assertDelayedFailures()
 
+    @unittest.expectedFailure
     @pn_pn_parallel
     def test_PnPn_Parallel(self):
         self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
@@ -1320,7 +1331,6 @@ class Hemi(NekTestCase):
         gmres = self.get_value_from_log('gmres: ', column=-7,)
         self.assertAlmostEqualDelayed(gmres, target_val=0., delta=39., label='gmres')
 
-        # TODO: This fails here and in legacy tests
         wmax = self.get_value_from_log('wmax', column=-2, row=-1)
         self.assertAlmostEqualDelayed(wmax, target_val=4.9173E-01, delta=1e-06, label='wmax')
 
@@ -1700,7 +1710,6 @@ class Mhd_GpfM(NekTestCase):
     def tearDown(self):
         self.move_logs()
 
-
 class Mhd_GpfB(NekTestCase):
     example_subdir = 'mhd'
     case_name = 'gpf_b'
@@ -1758,8 +1767,6 @@ class Mhd_GpfB(NekTestCase):
     def tearDown(self):
         self.move_logs()
 
-
-
 ####################################################################
 #  os7000; u3_t020_n13.rea
 ####################################################################
@@ -1772,6 +1779,7 @@ class Os7000(NekTestCase):
         self.build_tools(['genmap'])
         self.run_genmap()
 
+    @unittest.expectedFailure
     @pn_pn_serial
     def test_PnPn_Serial(self):
         self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
@@ -1784,12 +1792,12 @@ class Os7000(NekTestCase):
         gmres = self.get_value_from_log(label='gmres: ', column=-7)
         self.assertAlmostEqualDelayed(gmres, target_val=0., delta=43., label='gmres')
 
-        # TODO: This fails here and in legacy tests
         egn = self.get_value_from_log(label='egn', column=-2, row=-1)
         self.assertAlmostEqualDelayed(egn, target_val=4.74494769e-05, delta=1e-06, label='egn')
 
         self.assertDelayedFailures()
 
+    @unittest.expectedFailure
     @pn_pn_parallel
     def test_PnPn_Parallel(self):
         self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
@@ -1799,7 +1807,6 @@ class Os7000(NekTestCase):
         gmres = self.get_value_from_log(label='gmres: ', column=-7)
         self.assertAlmostEqualDelayed(gmres, target_val=0., delta=43., label='gmres')
 
-        # TODO: This fails here and in legacy tests
         egn = self.get_value_from_log(label='egn', column=-2, row=-1)
         self.assertAlmostEqualDelayed(egn, target_val=4.74494769e-05, delta=1e-06, label='egn')
 
@@ -1851,6 +1858,7 @@ class Peris(NekTestCase):
         self.build_tools(['genmap'])
         self.run_genmap()
 
+    @unittest.expectedFailure
     @pn_pn_serial
     def test_PnPn_Serial(self):
         self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
@@ -1861,6 +1869,7 @@ class Peris(NekTestCase):
         self.assertIsNotNullDelayed(phrase, label='ABORT: ')
         self.assertDelayedFailures()
 
+    @unittest.expectedFailure
     @pn_pn_parallel
     def test_PnPn_Parallel(self):
         self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
@@ -1911,6 +1920,7 @@ class Pipe_Helix(NekTestCase):
         self.build_tools(['genmap'])
         self.run_genmap()
 
+    @unittest.expectedFailure
     @pn_pn_serial
     def test_PnPn_Serial(self):
         self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
@@ -1923,12 +1933,12 @@ class Pipe_Helix(NekTestCase):
         gmres = self.get_value_from_log('gmres: ', column=-7)
         self.assertAlmostEqualDelayed(gmres, target_val=0., delta=61., label='gmres')
 
-        # TODO: This fails here and in legacy tests
         err2 = self.get_value_from_log('err2', column=-2, row=-1)
         self.assertAlmostEqualDelayed(err2, target_val=1.9077617E+00, delta=1e-06, label='err2')
 
         self.assertDelayedFailures()
 
+    @unittest.expectedFailure
     @pn_pn_parallel
     def test_PnPn_Parallel(self):
         self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
@@ -1938,7 +1948,6 @@ class Pipe_Helix(NekTestCase):
         gmres = self.get_value_from_log('gmres: ', column=-7)
         self.assertAlmostEqualDelayed(gmres, target_val=0., delta=61., label='gmres')
 
-        # TODO: This fails here and in legacy tests
         err2 = self.get_value_from_log('err2', column=-2, row=-1)
         self.assertAlmostEqualDelayed(err2, target_val=1.9077617E+00, delta=1e-06, label='err2')
 
@@ -2097,6 +2106,7 @@ class Rayleigh_Ray1(NekTestCase):
 
         self.assertDelayedFailures()
 
+    @unittest.expectedFailure
     @pn_pn_2_serial
     def test_PnPn2_Serial(self):
         self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
@@ -2114,6 +2124,7 @@ class Rayleigh_Ray1(NekTestCase):
 
         self.assertDelayedFailures()
 
+    @unittest.expectedFailure
     @pn_pn_2_parallel
     def test_PnPn2_Parallel(self):
         self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
@@ -2141,6 +2152,7 @@ class Rayleigh_Ray2(NekTestCase):
         self.run_genmap(rea_file='box')
         self.mvn('box', 'ray2')
 
+    @unittest.expectedFailure
     @pn_pn_serial
     def test_PnPn_Serial(self):
         self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
@@ -2158,6 +2170,7 @@ class Rayleigh_Ray2(NekTestCase):
 
         self.assertDelayedFailures()
 
+    @unittest.expectedFailure
     @pn_pn_parallel
     def test_PnPn_Parallel(self):
         self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
@@ -2172,6 +2185,7 @@ class Rayleigh_Ray2(NekTestCase):
 
         self.assertDelayedFailures()
 
+    @unittest.expectedFailure
     @pn_pn_2_serial
     def test_PnPn2_Serial(self):
         self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
@@ -2189,6 +2203,7 @@ class Rayleigh_Ray2(NekTestCase):
 
         self.assertDelayedFailures()
 
+    @unittest.expectedFailure
     @pn_pn_2_parallel
     def test_PnPn2_Parallel(self):
         self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
@@ -2344,6 +2359,7 @@ class Solid(NekTestCase):
         self.build_tools(['genmap'])
         self.run_genmap()
 
+    @unittest.expectedFailure
     @pn_pn_serial
     def test_PnPn_Serial(self):
         self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
@@ -2354,6 +2370,7 @@ class Solid(NekTestCase):
         self.assertIsNotNullDelayed(phrase, label='ABORT: ')
         self.assertDelayedFailures()
 
+    @unittest.expectedFailure
     @pn_pn_parallel
     def test_PnPn_Parallel(self):
         self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
@@ -2641,6 +2658,7 @@ class VarVis(NekTestCase):
         self.build_tools(['genmap'])
         self.run_genmap()
 
+    @unittest.expectedFailure
     @pn_pn_serial
     def test_PnPn_Serial(self):
         self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
@@ -2652,6 +2670,7 @@ class VarVis(NekTestCase):
         self.assertIsNotNullDelayed(phrase, label='ABORT')
         self.assertDelayedFailures()
 
+    @unittest.expectedFailure
     @pn_pn_parallel
     def test_PnPn_Parallel(self):
         self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')


### PR DESCRIPTION
This addresses issue #7.   Failures from the SVN version of Nek5000 have been labeled using unittest decorators until we can actually fix the underlying issue. Third-party test runners (nose, py.test, etc) should also be able to understand these.   