### PR TITLE
Completed benard tests

### DIFF
--- a/NekTests.py
+++ b/NekTests.py
@@ -275,7 +275,56 @@ class Axi(NekTestCase):
 # ####################################################################
 #
 # # TODO: implement benard
-# class Benard_Ray9:
+class Benard_Ray9(NekTestCase):
+    example_subdir = 'benard'
+    case_name = 'ray_9'
+
+    def setUp(self):
+        self.build_tools(['genmap'])
+        self.run_genmap(rea_file='ray_9')
+
+    @pn_pn_serial
+    def test_PnPn_Serial(self):
+        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
+        self.build_nek(usr_file='ray_9')
+        self.run_nek(rea_file='ray_9', step_limit=1000)
+
+        solver_time = self.get_value_from_log('total solver time', column=-2)
+        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=30., label='total solver time')
+
+        gmres = self.get_value_from_log('gmres: ', column=-7)
+        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=23., label='gmres')
+
+    @pn_pn_parallel
+    def test_PnPn_Parallel(self):
+        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
+        self.build_nek(usr_file='ray_9')
+        self.run_nek(rea_file='ray_9', step_limit=1000)
+
+        gmres = self.get_value_from_log('gmres: ', column=-7)
+        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=23., label='gmres')
+
+    @pn_pn_2_serial
+    def test_PnPn2_Serial(self):
+        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
+        self.build_nek(usr_file='ray_9')
+        self.run_nek(rea_file='ray_9', step_limit=1000)
+
+        solver_time = self.get_value_from_log('total solver time', column=-2)
+        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=40., label='total solver time')
+
+        gmres = self.get_value_from_log('gmres: ', column=-6)
+        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=11., label='gmres')
+
+    @pn_pn_2_parallel
+    def test_PnPn2_Parallel(self):
+        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
+        self.build_nek(usr_file='ray_9')
+        self.run_nek(rea_file='ray_9', step_limit=1000)
+
+        gmres = self.get_value_from_log('gmres: ', column=-6)
+        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=11., label='gmres')
+
 
 class Benard_RayDD(NekTestCase):
     example_subdir = 'benard'

--- a/NekTests.py
+++ b/NekTests.py
@@ -273,8 +273,7 @@ class Axi(NekTestCase):
 # ####################################################################
 # #  benard: ray_9.rea, ray_dd.rea, ray_dn.rea, ray_nn.rea
 # ####################################################################
-#
-# # TODO: implement benard
+
 class Benard_Ray9(NekTestCase):
     example_subdir = 'benard'
     case_name = 'ray_9'
@@ -479,6 +478,84 @@ class Benard_RayDN(NekTestCase):
         self.assertDelayedFailures()
 
     @skip("PnPn-2 test case for benard, ray_dn.rea is not run in parallel")
+    def test_PnPn2_Parallel(self):
+        pass
+
+    def tearDown(self):
+        self.move_logs()
+
+class Benard_RayNN(NekTestCase):
+    example_subdir = 'benard'
+    case_name = 'ray_nn'
+
+    def setUp(self):
+        self.build_tools(['genmap'])
+        self.run_genmap(rea_file='ray_nn')
+
+    @pn_pn_serial
+    def test_PnPn_Serial(self):
+        import lib.nekBinRun, lib.nekBinBuild, shutil
+        self.config_size(lx2='lx1', ly2='ly1', lz2='lz1')
+        shutil.copy(
+            os.path.join(self.examples_root, 'benard', 'ray_nn.map'),
+            os.path.join(self.examples_root, 'benard', 'benard_split', 'ray_nn.map')
+        )
+        lib.nekBinBuild.build_nek(
+            source_root = self.source_root,
+            usr_file    = 'ray_cr',
+            cwd         = os.path.join(self.examples_root, 'benard', 'benard_split'),
+            f77         = self.f77,
+            cc          = self.cc,
+            ifmpi       = str(self.ifmpi).lower(),
+            )
+        lib.nekBinRun.run_nek(
+            cwd        = os.path.join(self.examples_root, 'benard', 'benard_split'),
+            rea_file   = 'ray_nn',
+            ifmpi      = self.ifmpi,
+            log_suffix = self.log_suffix,
+            n_procs    = self.mpi_procs,
+            verbose    = self.verbose,
+            step_limit = None,
+            )
+
+        logfile=os.path.join(
+            self.examples_root,
+            'benard',
+            'benard_split',
+            '{0}.log.{1}{2}'.format('ray_nn', self.mpi_procs, self.log_suffix)
+        )
+
+        solver_time = self.get_value_from_log(label='total solver time', column=-2, logfile=logfile)
+        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=30., label='total solver time')
+
+        gmres = self.get_value_from_log('gmres: ', column=-6, logfile=logfile)
+        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=14., label='gmres')
+
+        rayleigh = self.get_value_from_log('rayleigh', column=-7, logfile=logfile)
+        self.assertAlmostEqualDelayed(rayleigh, target_val=657.511, delta=1., label='rayleigh')
+
+    @skip("PnPn test case for benard, ray_nn.rea is not run in parallel")
+    def test_PnPn_Parallel(self):
+        pass
+
+    @pn_pn_2_serial
+    def test_PnPn2_Serial(self):
+        self.config_size(lx2='lx1-2', ly2='ly1-2', lz2='lz1')
+        self.build_nek(usr_file='ray_cr')
+        self.run_nek(rea_file='ray_nn', step_limit=None)
+
+        solver_time = self.get_value_from_log('total solver time', column=-2)
+        self.assertAlmostEqualDelayed(solver_time, target_val=0.1, delta=20., label='total solver time')
+
+        gmres = self.get_value_from_log('gmres: ', column=-6)
+        self.assertAlmostEqualDelayed(gmres, target_val=0., delta=14., label='gmres')
+
+        rayleigh = self.get_value_from_log('rayleigh', column=-7)
+        self.assertAlmostEqualDelayed(rayleigh, target_val=657.511, delta=1., label='rayleigh')
+
+        self.assertDelayedFailures()
+
+    @skip("PnPn-2 test case for benard, ray_nn.rea is not run in parallel")
     def test_PnPn2_Parallel(self):
         pass
 


### PR DESCRIPTION
This completes the benard test cases that were previously covered by the legacy test suite.  These test cases are for:
- benard/ray_9.rea
- benard/ray_dd.rea
- benard/ray_dn.rea
- benard/ray_nn.rea