### PR TITLE
Display genmap, genbox output when VERBOSE_TESTS is enabled

### DIFF
--- a/lib/nekBinRun.py
+++ b/lib/nekBinRun.py
@@ -2,7 +2,7 @@ import os
 import sys
 from subprocess import call, check_call, PIPE, STDOUT, Popen, CalledProcessError
 
-def run_meshgen(command, stdin, cwd):
+def run_meshgen(command, stdin, cwd, verbose=False):
 
     logfile = os.path.join(cwd, '{0}.out'.format(os.path.basename(command)))
     stdin_bytes   = bytes("\n".join(stdin))
@@ -13,8 +13,14 @@ def run_meshgen(command, stdin, cwd):
     print('    Using working directory "{0}"'.format(cwd))
 
     try:
+        (stdoutdata, stderrdata) = Popen([command], stdin=PIPE, stderr=STDOUT, stdout=PIPE, cwd=cwd).communicate(stdin_bytes)
+
         with open(logfile, 'w') as f:
-            Popen([command], stdin=PIPE, stderr=STDOUT, stdout=f, cwd=cwd).communicate(stdin_bytes)
+            f.writelines(stdoutdata)
+
+        if verbose:
+            sys.stdout.write(stdoutdata)
+
     except (OSError, CalledProcessError) as E:
         # TODO: Change to warnings.warn()
         print('Could not complete {0}!  Caught error: "{1}".  Check "{2}" for details.'.format(command, E, logfile))

--- a/lib/nekTestCase.py
+++ b/lib/nekTestCase.py
@@ -278,6 +278,7 @@ class NekTestCase(unittest.TestCase):
             command = os.path.join(self.tools_bin, 'genmap'),
             stdin   = [rea_file, tol],
             cwd     = os.path.join(self.examples_root, cls.example_subdir),
+            verbose = self.verbose
         )
 
     def run_genbox(self, box_file=None):
@@ -294,6 +295,7 @@ class NekTestCase(unittest.TestCase):
             command = os.path.join(self.tools_bin, 'genbox'),
             stdin   = [box_file],
             cwd     = os.path.join(self.examples_root, self.__class__.example_subdir),
+            verbose = self.verbose
         )
 
     def run_n2to3(self, stdin):


### PR DESCRIPTION
genmap and genbox are run as needed during the NekTests.py.  Previously, the stdout+stderr from genbox/genmap were always dumped to logfiles (named genmap.out and genbox.out).  However, there was no option to display the stdout+stderr to the terminal.

In this PR, the VERBOSE_TESTS variable (an existing feature) now causes genmap and genbox to display stdout+stderr to the terminal.  This should be very helpful during the Travis tests, since the genmap.out/genbox.out are not visible in Travis but the terminal output is visible.  