### PR TITLE
VERBOSE_TESTS displays compiler output for maketools

### DIFF
--- a/lib/nekBinBuild.py
+++ b/lib/nekBinBuild.py
@@ -4,7 +4,7 @@ from subprocess import call, check_call, Popen, PIPE, STDOUT
 from lib.nekFileConfig import config_makenek, config_maketools, config_basics_inc
 
 def build_tools(tools_root, tools_bin, f77=None, cc=None, bigmem=None,
-                targets=('clean', 'all')):
+                targets=('clean', 'all'), verbose=False):
 
     print('Compiling tools... ')
     print('    Using source directory "{0}"'.format(tools_root))
@@ -34,13 +34,23 @@ def build_tools(tools_root, tools_bin, f77=None, cc=None, bigmem=None,
 
         with open(maketools_log, 'w') as f:
             for t in targets:
-                check_call(
-                    [maketools_out, t, tools_bin],
-                    stderr=STDOUT,
-                    stdout=f,
-                    cwd=tools_root
-                )
-
+                if verbose:
+                    proc = Popen(
+                        [maketools_out, t, tools_bin],
+                        cwd=tools_root,
+                        stderr=STDOUT,
+                        stdout=PIPE
+                    )
+                    for line in proc.stdout:
+                        sys.stdout.write(line)
+                        f.write(line)
+                else:
+                    check_call(
+                        [maketools_out, t, tools_bin],
+                        stderr=STDOUT,
+                        stdout=f,
+                        cwd=tools_root
+                    )
     except:
         print('Could not compile tools! Check "{0}" for details.'.format(maketools_log))
         raise

--- a/lib/nekTestCase.py
+++ b/lib/nekTestCase.py
@@ -238,7 +238,7 @@ class NekTestCase(unittest.TestCase):
 
         print("Finished getting setup options!")
 
-    def build_tools(self, targets=None, tools_root=None, tools_bin=None, f77=None, cc=None, bigmem=None):
+    def build_tools(self, targets=None, tools_root=None, tools_bin=None, f77=None, cc=None, bigmem=None, verbose=None):
         from lib.nekBinBuild import build_tools
         build_tools(
             targets    = targets    if targets    else ('clean', 'genmap'),
@@ -246,7 +246,8 @@ class NekTestCase(unittest.TestCase):
             tools_bin  = tools_bin  if tools_bin  else self.tools_bin,
             f77        = f77        if f77        else 'gfortran',
             cc         = cc         if cc         else 'gcc',
-            bigmem     = bigmem     if bigmem     else 'false'
+            bigmem     = bigmem     if bigmem     else 'false',
+            verbose    = verbose    if verbose    else self.verbose
         )
 
     def config_size(self, infile=None, outfile=None, lx2=None, ly2=None, lz2=None):


### PR DESCRIPTION
NekTests.py will now display stdout/stderr from maketools if VERBOSE_TESTS is enabled.  Stdout/stderr will always be output to logfile, regardless of VERBOSE_TESTS. Similar issue to #18.  Should help debug Travis tests.  