### PR TITLE
Compile with "-g" by default.

### DIFF
--- a/lib/nekFileConfig.py
+++ b/lib/nekFileConfig.py
@@ -1,6 +1,6 @@
 import os, stat, re
 
-def config_makenek(infile, outfile, source_root=None, f77=None, cc=None, ifmpi=None):
+def config_makenek(infile, outfile, source_root=None, f77=None, cc=None, ifmpi=None, g='-g'):
 
     with open(infile, 'r') as f:
         lines = f.readlines()
@@ -16,6 +16,9 @@ def config_makenek(infile, outfile, source_root=None, f77=None, cc=None, ifmpi=N
                  for l in lines]
     if ifmpi:
         lines = [re.sub(r'^#*IFMPI=\"+.+?\"+', r'IFMPI="{0}"'.format(ifmpi), l)
+                 for l in lines]
+    if g:
+        lines = [re.sub(r'^#*G=\"+.+?\"+', r'G="{0}"'.format(g), l)
                  for l in lines]
 
     lines = [re.sub(r'(^source\s+\$SOURCE_ROOT/makenek.inc)', r'\g<1> >compiler.out', l)


### PR DESCRIPTION
This allows backtraces from exittt to be captured by NekTests.py when compiling with PGI