### PR TITLE
removed time being set to outerloop value

### DIFF
--- a/smoother/smoothlx.f
+++ b/smoother/smoothlx.f
@@ -81,7 +81,6 @@ ccc   GET INITIAL ENERGY
 ccc   START SMOOTHING HERE
       do j=1,nouter
          f1pre = f1
-         time = j
          if (nid.eq.0.and.loglevel.ge.2) 
      $     write(6,'(A,I5)') 'SMOOTHER-iteration',j
          mtyp = 1 !if mtyp = 1, jacobian, 2 = l^2, 3 - scale jacobian


### PR DESCRIPTION
I had initially done this to keep a counter for debugging when analyzing the checkpoint files in visit. I guess now that the smoother is online, we wouldn't want time to be modified by the smoother.