### PR TITLE
fixed to work with latest changes to neknek

### DIFF
--- a/eddy_neknek/eddy_uv.usr
+++ b/eddy_neknek/eddy_uv.usr
@@ -150,12 +150,12 @@ c
 
 c    Global error calculation
       if (IFNEKNEK) then 
-      umx_gl = uglamax(vx,n)
-      vmx_gl = uglamax(vy,n)
-      uex_gl = uglamax(ue,n)
-      vex_gl = uglamax(ve,n)
-      udx_gl = uglamax(ud,n)
-      vdx_gl = uglamax(vd,n)
+      umx_gl = ms_glamax(vx,n)
+      vmx_gl = ms_glamax(vy,n)
+      uex_gl = ms_glamax(ue,n)
+      vex_gl = ms_glamax(ve,n)
+      udx_gl = ms_glamax(ud,n)
+      vdx_gl = ms_glamax(vd,n)
       end if  
 
 
@@ -191,25 +191,17 @@ c     NOTE ::: This subroutine MAY NOT be called by every process
       ie = gllel(ieg)
 
       if (imask(ix,iy,iz,ie).eq.0) then
-      ux=0.0
-      uy=0.0
-      uz=0.0
-      temp=0.0
+       ux=0.0
+       uy=0.0
+       uz=0.0
+       temp=0.0
       else      
-
-      if (igeom.le.2) then
-         ux = ubc(ix,iy,iz,ie,1)
-         uy = ubc(ix,iy,iz,ie,2)
-         uz = ubc(ix,iy,iz,ie,3)
-         if (nfld_neknek.gt.3) temp = ubc(ix,iy,iz,ie,ldim+2)
-      else
-         ux = valint(ix,iy,iz,ie,1)
-         uy = valint(ix,iy,iz,ie,2)
-         uz = valint(ix,iy,iz,ie,3)
-         if (nfld_neknek.gt.3) temp = valint(ix,iy,iz,ie,ldim+2)
+       ux = valint(ix,iy,iz,ie,1)
+       uy = valint(ix,iy,iz,ie,2)
+       uz = valint(ix,iy,iz,ie,3)
+       if (nfld_neknek.gt.3) temp = valint(ix,iy,iz,ie,ldim+2)
       endif
 
-      end if
       return
       end
 c-----------------------------------------------------------------------
@@ -288,10 +280,6 @@ c-----------------------------------------------------------------------
 
       call cmult(xm1,twopi,n)
       call cmult(ym1,twopi,n)
-
-c     This routine initializes the mulitdomain coupling          
-      
-      call multimesh_create
 
       return
       end


### PR DESCRIPTION
Does not call multimesh_create in usrdat2, utilizes only valint array in userbc, and calls the right routines for finding multisession max/min.